### PR TITLE
Fix resource path name

### DIFF
--- a/src/main/java/org/pleutre/jmeter/plugin/HttpServer.java
+++ b/src/main/java/org/pleutre/jmeter/plugin/HttpServer.java
@@ -51,7 +51,7 @@ public class HttpServer extends NanoHTTPD {
 	 * @throws IOException if file can not be read/created
 	 */
 	private String readReponseFile() throws URISyntaxException, IOException {
-		URI uri = HttpServer.class.getResource("response.xml").toURI();
+		URI uri = HttpServer.class.getResource("/response.xml").toURI();
 		LOG.info("uri = " + uri);
 		Map<String, String> env = new HashMap<>(); 
 		env.put("create", "true");


### PR DESCRIPTION
According to https://docs.oracle.com/javase/8/docs/api/java/lang/Class.html#getResource-java.lang.String-